### PR TITLE
Remove async validation usage

### DIFF
--- a/test/mocks/mock-schema.ts
+++ b/test/mocks/mock-schema.ts
@@ -6,3 +6,16 @@ export const MockSchema = Joi.object().keys({
   firstName: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly).required(),
   lastName: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly).required()
 });
+
+export const validModel = {
+  id: '1',
+  firstName: 'Firstname',
+  lastName: 'Lastname'
+}
+
+export const invalidModel = {
+  id: '1',
+  firstName: 'Firstname',
+  lastName: 'Lastname',
+  notGonnaWork: 'But let\'s try'
+}

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -1,46 +1,54 @@
-import { ValidateSchema } from '../lib/index';
-import { MockSchema } from './mocks/mock-schema';
+import { ValidateSchema, Validate, payload } from '../lib/index';
+import { MockSchema, validModel, invalidModel } from './mocks/mock-schema';
 
 import * as assert from 'assert';
 
 describe('Validation', () => {
   describe('ValidateSchema()', () => {
 
-    it('should validate correctly', async () => {
-      const body = {
-        id: '1',
-        firstName: 'Firstname',
-        lastName: 'Lastname'
-      };
-      const result = await ValidateSchema(body, MockSchema);
+    it('should validate correctly', () => {
+      const result = ValidateSchema(validModel, MockSchema);
       assert.deepEqual(result, { valid: true });
     });
 
-    it('should return error when invalid body supplied', async () => {
-      const body = null;
-      const result = await ValidateSchema(body, MockSchema);
+    it('should return error when invalid body supplied', () => {
+      const result = ValidateSchema(null, MockSchema);
       assert.deepEqual(result, { valid: false, error: { code: 422, message: 'Invalid Request: An incorrect payload was supplied.' } });
     });
 
-    it('should return error when invalid schema supplied', async () => {
-      const body = {
-        id: '1',
-        firstName: 'Firstname',
-        lastName: 'Lastname'
-      };
-      const result = await ValidateSchema(body, null);
+    it('should return error when invalid schema supplied', () => {
+      const result = ValidateSchema(validModel, null);
       assert.deepEqual(result, { valid: false, error: { code: 422, message: 'Request was invalid: ValidationError: \"value\" must be one of [null]' } });
     });
 
-    it('should return error when schema doesn\'t validate', async () => {
-      const body = {
-        id: '1',
-        firstName: 'Firstname',
-        lastName: 'Lastname',
-        notGonnaWork: 'But let\'s try'
-      };
-      const result = await ValidateSchema(body, MockSchema);
+    it('should return error when schema doesn\'t validate', () => {
+      const result = ValidateSchema(invalidModel, MockSchema);
       assert.deepEqual(result, { valid: false, error: { code: 422, message: `Request was invalid: ValidationError: \"notGonnaWork\" is not allowed` } });
+    });
+  });
+
+  describe('Decorators', () => {
+    class Fixture {
+      @Validate(MockSchema)
+      testingMethod(@payload data: any): number {
+        return 3;
+      }
+    }
+
+    it('should return if the payload validates', () => {
+      const fixture = new Fixture();
+      const result = fixture.testingMethod(validModel);
+      assert.equal(result, 3);
+    });
+
+    it('should throw if the payload does not validate', () => {
+      const fixture = new Fixture();
+      assert.throws(() => fixture.testingMethod(invalidModel));
+    });
+
+    it('should not throw if the payload does validate', () => {
+      const fixture = new Fixture();
+      assert.doesNotThrow(() => fixture.testingMethod(validModel));
     });
   });
 });

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -35,19 +35,22 @@ describe('Validation', () => {
       }
     }
 
+    let fixture;
+
+    beforeEach(() => {
+      fixture = new Fixture();
+    });
+
     it('should return if the payload validates', () => {
-      const fixture = new Fixture();
       const result = fixture.testingMethod(validModel);
       assert.equal(result, 3);
     });
 
     it('should throw if the payload does not validate', () => {
-      const fixture = new Fixture();
       assert.throws(() => fixture.testingMethod(invalidModel));
     });
 
     it('should not throw if the payload does validate', () => {
-      const fixture = new Fixture();
       assert.doesNotThrow(() => fixture.testingMethod(validModel));
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,11 @@
     ],
     "target": "es5",
     "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "declaration": true,
     "rootDir": ".",
     "outDir": "build",
     "types": ["node", "mocha"]
-  },
-  "include": [
-    "index.ts",
-    "lib/**/*"
-  ]
+  }
 }


### PR DESCRIPTION
For how we expect to use this, I think we need to remove using the async validation functionality of joi. The async validation is not actually async anyway, so we're not losing any functionality.

Using the fake async version breaks the usefulness of the decorators, since we cannot convert a non-async function to an async function via a decorator. Doing so is not type safe and users would be unaware that they have a promise being returned and need to chain or convert it. Since I don't expect truly async validations to be something we implement in this library (even if Joi ever were to support it) I think we should remove it and just use the synchronous joi API.