### PR TITLE
Update webpack configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -697,6 +697,15 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@types/clean-webpack-plugin": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/clean-webpack-plugin/-/clean-webpack-plugin-0.1.2.tgz",
+      "integrity": "sha512-Io2JfBqqEB+ZpIXpLpGR6udFhmv5kjkXko6RI3j/lk2mccB5Ar+VHb7vGG3aI8XrauajNpxzajZFcsvnpj/Qkw==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "4.1.4"
+      }
+    },
     "@types/jest": {
       "version": "22.2.3",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
@@ -762,6 +771,15 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.9.2.tgz",
       "integrity": "sha512-RQub8vZH3P8Afwx+JezWZ2aF0Acy+q1bGctLTAaYVwPecu8XEUsO4Lc0LHHHjWnxF57XcoVxBUM7Sbcvh6B/eQ==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "4.1.4"
+      }
+    },
+    "@types/webpack-merge": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-merge/-/webpack-merge-4.1.3.tgz",
+      "integrity": "sha512-VdmNuYIvIouYlCI73NLKOE1pOVAxv5m5eupvTemojZz9dqghoQXmeEveI6CqeuWpCH6x6FLp6+tXM2sls20/MA==",
       "dev": true,
       "requires": {
         "@types/webpack": "4.1.4"
@@ -2941,6 +2959,15 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
+      }
+    },
+    "clean-webpack-plugin": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
+      "integrity": "sha512-M1Li5yLHECcN2MahoreuODul5LkjohJGFxLPTjl3j1ttKrF5rgjZET1SJduuqxLAuT1gAPOdkhg03qcaaU1KeA==",
+      "dev": true,
+      "requires": {
+        "rimraf": "2.6.2"
       }
     },
     "cli-cursor": {
@@ -11828,6 +11855,15 @@
             "camelcase": "4.1.0"
           }
         }
+      }
+    },
+    "webpack-merge": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
+      "integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "test": "jest",
-    "build": "webpack",
+    "dev": "webpack --config webpack.dev.ts",
+    "build": "webpack --config webpack.prod.ts",
     "prepare": "rm -rf build && npm run build"
   },
   "author": "Semantic Bits",
@@ -31,14 +32,17 @@
     "isemail": false
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.46",
+    "@babel/preset-env": "^7.0.0-beta.46",
+    "@types/clean-webpack-plugin": "^0.1.2",
     "@types/jest": "^22.2.3",
     "@types/joi": "^13.0.8",
     "@types/node": "^10.0.0",
     "@types/webpack": "^4.1.4",
     "@types/webpack-bundle-analyzer": "^2.9.2",
-    "@babel/core": "^7.0.0-beta.46",
-    "@babel/preset-env": "^7.0.0-beta.46",
+    "@types/webpack-merge": "^4.1.3",
     "babel-loader": "^8.0.0-beta.2",
+    "clean-webpack-plugin": "^0.1.19",
     "jest": "^22.4.3",
     "ts-jest": "^22.4.4",
     "ts-loader": "^4.2.0",
@@ -46,7 +50,8 @@
     "typescript": "^2.8.3",
     "webpack": "^4.6.0",
     "webpack-bundle-analyzer": "^2.11.1",
-    "webpack-cli": "^2.0.15"
+    "webpack-cli": "^2.0.15",
+    "webpack-merge": "^4.1.2"
   },
   "dependencies": {
     "joi": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest",
     "dev": "webpack --config webpack.dev.ts",
     "build": "webpack --config webpack.prod.ts",
-    "prepare": "rm -rf build && npm run build"
+    "prepare": "npm run build"
   },
   "author": "Semantic Bits",
   "contributors": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,5 @@
   },
   "include": [
     "./lib/**/*.ts"
-  ],
-  "exclude": [
-    "./test/**/*.ts",
-    "./webpack.config.ts"
   ]
 }

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -1,16 +1,11 @@
 import * as path from 'path';
 import * as webpack from 'webpack';
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import CleanWebpackPlugin from 'clean-webpack-plugin';
 
 const config: webpack.Configuration = {
   entry: './index.ts',
-  mode: 'none',
-  devtool: 'source-map',
   plugins: [
-    new BundleAnalyzerPlugin({
-      openAnalyzer: false,
-      analyzerMode: 'static'
-    })
+    new CleanWebpackPlugin(['build'])
   ],
   output: {
     library: 'wi-validation',

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -1,0 +1,15 @@
+import * as webpack from 'webpack';
+import merge from 'webpack-merge';
+import common from './webpack.common';
+
+const config: webpack.Configuration = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+  stats: 'errors-only',
+  watch: true,
+  watchOptions: {
+    ignored: /node_modules/
+  }
+});
+
+export default config;

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,0 +1,16 @@
+import merge from 'webpack-merge';
+import common from './webpack.common';
+import * as webpack from 'webpack';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+const config: webpack.Configuration = merge(common, {
+  mode: 'production',
+  plugins: [
+    new BundleAnalyzerPlugin({
+      openAnalyzer: false,
+      analyzerMode: 'static'
+    })
+  ]
+});
+
+export default config;

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -4,7 +4,7 @@ import * as webpack from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 const config: webpack.Configuration = merge(common, {
-  mode: 'production',
+  mode: 'none',
   plugins: [
     new BundleAnalyzerPlugin({
       openAnalyzer: false,


### PR DESCRIPTION
Updating the webpack configs and splitting them into dev (with watching + source maps) and prod. I tried enabling the webpack production mode, but it appears that our bundling on the client is a bit more aggressive which results in a smaller build. If we enable production here, our client bundling can't make as many optimizations since the lib is already minified.