### PR TITLE
bug/QPPBSR-4225: Checking blank values

### DIFF
--- a/lib/regexes.ts
+++ b/lib/regexes.ts
@@ -3,6 +3,7 @@ export const Regexes = {
   lettersNumbersAndSymbolsOnly: /^[A-Za-z0-9'\-,\/ ]+$/,
   lettersAndSymbolsOnly: /^[A-Za-z'\-\/ ]+$/,
   capitalLettersAndNumbersOnly: /^[0-9A-Z]+$/,
+  containsNonWhitespace: /\S/,
   numbersOnly: /^[0-9]+$/,
   numbersOnlyAndEmptyString: /^(\s{0}|\d+)$/,
   validAddress: /^[0-9A-Za-z'\-\/#_. ]+$/,

--- a/lib/schema/clinic.ts
+++ b/lib/schema/clinic.ts
@@ -2,12 +2,12 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const ClinicSchema = Joi.object().keys({
-  clinicId: Joi.string().max(30).regex(Regexes.lettersAndNumbersOnly).required(),
-  name: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly).required(),
-  address1: Joi.string().max(100).regex(Regexes.validAddress).optional().allow(null),
-  address2: Joi.string().max(100).regex(Regexes.validAddress).optional().allow(null),
-  city: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly).optional().allow(null),
+  clinicId: Joi.string().max(30).regex(Regexes.lettersAndNumbersOnly, 'LettersAndNumbersOnly').required(),
+  name: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly, 'LettersNumbersAndSymbolsOnly').regex(Regexes.containsNonWhitespace, 'ContainsNonWhitespace').required(),
+  address1: Joi.string().max(100).regex(Regexes.validAddress, 'ValidAddress').optional().allow(null),
+  address2: Joi.string().max(100).regex(Regexes.validAddress, 'ValidAddress').optional().allow(null),
+  city: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly, 'LettersAndSymbolsOnly').optional().allow(null),
   state: Joi.string().optional().allow(null),
-  zipCode: Joi.string().min(5).max(10).regex(Regexes.validZipCode).optional().allow(null),
+  zipCode: Joi.string().min(5).max(10).regex(Regexes.validZipCode, 'ValidZipCode').optional().allow(null),
   organizationId: Joi.number().optional().allow(null)
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/decorators.spec.ts
+++ b/test/decorators.spec.ts
@@ -36,7 +36,7 @@ describe('Decorators', () => {
   describe('PickAllowableFields', () => {
     class Fixture {
       @PickAllowableFields(MockSchema)
-      testingMethod(data: any): any {
+      testingMethod(@payload data: any): any {
         return data;
       }
     }
@@ -47,7 +47,7 @@ describe('Decorators', () => {
       fixture = new Fixture();
     });
 
-    it('should return only allowable fields', () => {
+    it('should return the picked properties', () => {
       const result: any = fixture.testingMethod(invalidModel);
       expect(result).toEqual(validModel);
     });

--- a/test/regexes.spec.ts
+++ b/test/regexes.spec.ts
@@ -13,10 +13,12 @@ describe('Regexes', () => {
           return Regexes.lettersAndSymbolsOnly.test(test);
         case 'CapitalLettersAndNumbersOnly':
           return Regexes.capitalLettersAndNumbersOnly.test(test);
+        case 'ContainsNonWhitespace':
+          return Regexes.containsNonWhitespace.test(test);
         case 'NumbersOnly':
           return Regexes.numbersOnly.test(test);
         case 'NumbersOnlyAndEmptyString':
-          return Regexes.numbersOnlyAndEmptyString.test(test);          
+          return Regexes.numbersOnlyAndEmptyString.test(test);
         case 'ValidAddress':
           return Regexes.validAddress.test(test);
         case 'ValidZipCode':
@@ -87,6 +89,18 @@ describe('Regexes', () => {
 
     it('should return false if does not validates', () => {
       const result: any = fixture.testingMethod('CapitalLettersAndNumbersOnly', 'caps123');
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('ContainsNonWhitespace', () => {
+    it('should return true if validates', () => {
+      const result: any = fixture.testingMethod('ContainsNonWhitespace', 'nospaceshere');
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if does not validates', () => {
+      const result: any = fixture.testingMethod('ContainsNonWhitespace', '    ');
       expect(result).toEqual(false);
     });
   });


### PR DESCRIPTION
Adding a new regex to check for empty values. Will be opening a PR on the client and api to address this as well. The api will simply be the bump in version. The client will apply the regex to the Angular form.