### PR TITLE
feature/QPPBSR-4716: Removing status field and bumping version

### DIFF
--- a/lib/schema/measure.ts
+++ b/lib/schema/measure.ts
@@ -1,13 +1,6 @@
 import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
-export enum MeasureStatus {
-  complete = 'COMPLETE',
-  incomplete = 'INCOMPLETE',
-  skipped = 'SKIPPED',
-  notRanked = 'NOT_RANKED'
-}
-
 export enum MeasureConfirmedOptions {
   Y = 'Y',
   N = 'N',

--- a/lib/schema/measure.ts
+++ b/lib/schema/measure.ts
@@ -20,7 +20,6 @@ export enum MeasureConfirmedOptions {
 
 export const MeasureMap = {
   name: Joi.string().max(128).regex(Regexes.lettersNumbersAndSymbolsOnly).required(), // candidate key, not updatable
-  status: Joi.string().valid(Object.values(MeasureStatus)).optional().allow(null), // TODO: this is not updatable and thus shouldn't be sent...
   confirmed: Joi.string().valid(Object.values(MeasureConfirmedOptions)).optional().allow(null),
   skippedReason: Joi.string().max(1024).optional().allow(null),
   helpDeskTicket: Joi.string().max(15).optional().allow(null),

--- a/lib/schema/measure.ts
+++ b/lib/schema/measure.ts
@@ -20,6 +20,3 @@ export const MeasureMap = {
 };
 
 export const MeasureSchema = Joi.object(MeasureMap);
-
-/** Deprecated */
-export const BeneficiaryMeasureSchema = Joi.object(MeasureMap);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",


### PR DESCRIPTION
Removing `status` from measure schema and updating version to `0.11.4`