### PR TITLE
QPPBSR-4427: Rename back to bene map

### DIFF
--- a/lib/schema/beneficiary.ts
+++ b/lib/schema/beneficiary.ts
@@ -7,7 +7,7 @@ export enum Gender {
   Unknown = 'UNKNOWN',
 }
 
-const fields = {
+export const BeneficiaryMap = {
   firstName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnly),
   lastName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnly),
   gender: Joi.string().valid(Object.values(Gender)),
@@ -22,14 +22,4 @@ const fields = {
   qualificationComments: Joi.string().allow(null)
 };
 
-// This schema includes required fields, should be used when creating a bene.
-export const BeneficiaryMap = {
-  ...fields,
-  firstName: fields.firstName.required(),
-  lastName: fields.lastName.required(),
-  gender: fields.gender.required(),
-  dateOfBirth: fields.dateOfBirth.required()
-};
-
 export const BeneficiarySchema = Joi.object().keys(BeneficiaryMap);
-export const BeneficiaryFieldsSchema = Joi.object().keys(fields);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/beneficiary.spec.ts
+++ b/test/beneficiary.spec.ts
@@ -72,4 +72,32 @@ describe('BeneficiaryFieldsSchema', () => {
     }, BeneficiaryFieldsSchema);
     expect(result.error).toBeNull();
   });
+
+  it('should allow null firstName', () => {
+    const result = Joi.validate({
+      firstName: null
+    }, BeneficiaryFieldsSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null lastName', () => {
+    const result = Joi.validate({
+      lastName: null
+    }, BeneficiaryFieldsSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null dateOfBirth', () => {
+    const result = Joi.validate({
+      dateOfBirth: null
+    }, BeneficiaryFieldsSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null gender', () => {
+    const result = Joi.validate({
+      gender: null
+    }, BeneficiaryFieldsSchema);
+    expect(result.error).not.toBeNull();
+  });
 });

--- a/test/beneficiary.spec.ts
+++ b/test/beneficiary.spec.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-import { BeneficiarySchema, BeneficiaryFieldsSchema } from '../lib/schema/beneficiary';
+import { BeneficiarySchema } from '../lib/schema/beneficiary';
 
 describe('BeneficiarySchema', () => {
   describe('gender', () => {
@@ -55,49 +55,49 @@ describe('BeneficiarySchema', () => {
   });
 });
 
-describe('BeneficiaryFieldsSchema', () => {
+describe('BeneficiarySchema', () => {
   it('should validate correctly', () => {
     const result = Joi.validate({
       firstName: 'Joe',
       lastName: 'Doe',
       gender: 'MALE',
       dateOfBirth: Date.now().toString()
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).toBeNull();
   });
 
   it('should allow partial objects', () => {
     const result = Joi.validate({
       firstName: 'Joe'
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).toBeNull();
   });
 
   it('should allow null firstName', () => {
     const result = Joi.validate({
       firstName: null
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).not.toBeNull();
   });
 
   it('should allow null lastName', () => {
     const result = Joi.validate({
       lastName: null
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).not.toBeNull();
   });
 
   it('should allow null dateOfBirth', () => {
     const result = Joi.validate({
       dateOfBirth: null
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).not.toBeNull();
   });
 
   it('should allow null gender', () => {
     const result = Joi.validate({
       gender: null
-    }, BeneficiaryFieldsSchema);
+    }, BeneficiarySchema);
     expect(result.error).not.toBeNull();
   });
 });


### PR DESCRIPTION
Moving back to the original name since the previous bene map with explicitly required fields is not necessary.  Added some tests to show nullability.