### PR TITLE
Measure Schema Cleanup

### DIFF
--- a/lib/schema/measure.ts
+++ b/lib/schema/measure.ts
@@ -1,20 +1,8 @@
 import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
-export enum MeasureConfirmedOptions {
-  Y = 'Y',
-  N = 'N',
-  NCD = 'NCD',
-  DE = 'DE',
-  NOCAR = 'NOCAR',
-  NOAGE = 'NOAGE',
-  NOGENDER = 'NOGENDER'
-}
-
 export const MeasureMap = {
   name: Joi.string().max(128).regex(Regexes.lettersNumbersAndSymbolsOnly).required(), // candidate key, not updatable
-  confirmed: Joi.string().valid(Object.values(MeasureConfirmedOptions)).optional().allow(null),
-  skippedReason: Joi.string().max(1024).optional().allow(null),
   helpDeskTicket: Joi.string().max(15).optional().allow(null),
   comments: Joi.string().optional().allow(null)
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",


### PR DESCRIPTION
Removed the obsolete confirmed property and the readonly skippedReason property from the Measure schema