### PR TITLE
QPPBSR-4944: Removed skippedReason from bene schema

### DIFF
--- a/lib/schema/beneficiary.ts
+++ b/lib/schema/beneficiary.ts
@@ -14,7 +14,6 @@ export const BeneficiaryMap = {
   dateOfBirth: Joi.date(),
   mrn: Joi.string().max(128).allow(null),
   comments: Joi.string().max(1000).allow(null),
-  skippedReason: Joi.string().allow(null),
   medicalRecordFound: Joi.string().allow(null),
   medicalNotQualifiedReason: Joi.string().allow(null),
   medicalNotQualifiedDate: Joi.date().allow(null),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.11.8",
+  "version": "0.12.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/beneficiary.spec.ts
+++ b/test/beneficiary.spec.ts
@@ -100,4 +100,11 @@ describe('BeneficiarySchema', () => {
     }, BeneficiarySchema);
     expect(result.error).not.toBeNull();
   });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      skippedReason: 'some reason'
+    }, BeneficiarySchema);
+    expect(result.error).not.toBeNull();
+  });
 });


### PR DESCRIPTION
Remove `skippedReason` from the beneficiarySchema. It should not be updatable from the API.