### PR TITLE
feature/QPPBSR-4487: Updating required fields to catch blank values

### DIFF
--- a/lib/schema/clinic.ts
+++ b/lib/schema/clinic.ts
@@ -2,8 +2,8 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const ClinicMap = {
-  clinicId: Joi.string().max(9).regex(Regexes.lettersAndNumbersOnly, 'LettersAndNumbersOnly').required(),
-  name: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly, 'LettersNumbersAndSymbolsOnly').regex(Regexes.containsNonWhitespace, 'ContainsNonWhitespace').required(),
+  clinicId: Joi.string().max(9).regex(Regexes.lettersAndNumbersOnly, 'LettersAndNumbersOnly').trim().required(),
+  name: Joi.string().max(100).regex(Regexes.lettersNumbersAndSymbolsOnly, 'LettersNumbersAndSymbolsOnly').trim().required(),
   address1: Joi.string().max(100).regex(Regexes.validAddress, 'ValidAddress').optional().allow(null),
   address2: Joi.string().max(100).regex(Regexes.validAddress, 'ValidAddress').optional().allow(null),
   city: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly, 'LettersAndSymbolsOnly').optional().allow(null),

--- a/lib/schema/measure.ts
+++ b/lib/schema/measure.ts
@@ -2,7 +2,7 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const MeasureMap = {
-  name: Joi.string().max(128).regex(Regexes.lettersNumbersAndSymbolsOnly).required(), // candidate key, not updatable
+  name: Joi.string().max(128).regex(Regexes.lettersNumbersAndSymbolsOnly).trim().required(), // candidate key, not updatable
   helpDeskTicket: Joi.string().max(15).optional().allow(null),
   comments: Joi.string().max(1000).optional().allow(null)
 };

--- a/lib/schema/notification.ts
+++ b/lib/schema/notification.ts
@@ -9,7 +9,7 @@ export const NotificationMap = {
   userId: Joi.number().max(99999999999).required(),
   organizationId: Joi.number().max(99999999999).required(),
   messageType: Joi.string().valid(Object.values(NotificationMessageTypes)).required(),
-  message: Joi.string().max(255).required(),
+  message: Joi.string().max(255).trim().required(),
   read: Joi.boolean().required()
 };
 

--- a/lib/schema/organization-address.ts
+++ b/lib/schema/organization-address.ts
@@ -2,9 +2,9 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const OrganizationAddressMap = {
-  address1: Joi.string().max(128).regex(Regexes.validAddress).required(),
+  address1: Joi.string().max(128).regex(Regexes.validAddress).trim().required(),
   address2: Joi.string().max(128).regex(Regexes.validAddress).optional().allow(null),
-  city: Joi.string().max(128).required(),
+  city: Joi.string().max(128).trim().required(),
   state: Joi.string().length(2).regex(Regexes.stateAbbreviations).required(),
   zipCode: Joi.string().min(5).max(10).regex(Regexes.validZipCode).required(),
   isPrimary: Joi.boolean().required()

--- a/lib/schema/organization-contact.ts
+++ b/lib/schema/organization-contact.ts
@@ -2,10 +2,10 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const OrganizationContactMap = {
-  firstName: Joi.string().max(32).regex(Regexes.lettersAndSymbolsOnly).required(),
-  lastName: Joi.string().max(32).regex(Regexes.lettersAndSymbolsOnly).required(),
+  firstName: Joi.string().max(32).regex(Regexes.lettersAndSymbolsOnly).trim().required(),
+  lastName: Joi.string().max(32).regex(Regexes.lettersAndSymbolsOnly).trim().required(),
   email: Joi.string().max(100).regex(Regexes.email).required(),
-  phone: Joi.string().length(10).regex(Regexes.numbersOnly).required(),
+  phone: Joi.string().length(10).regex(Regexes.numbersOnly).trim().required(),
   phoneExtension: Joi.string().optional().max(6).allow(null)
 };
 

--- a/lib/schema/organization.ts
+++ b/lib/schema/organization.ts
@@ -8,7 +8,7 @@ export enum GroupSize {
 }
 
 export const OrganizationMap = {
-  name: Joi.string().max(128).regex(Regexes.containsNonWhitespace, 'ContainsNonWhitespace').required(),
+  name: Joi.string().max(128).trim().required(),
   nickname: Joi.string().max(128).regex(Regexes.containsNonWhitespace, 'ContainsNonWhitespace').allow(null),
   groupSize: Joi.string().valid(Object.values(GroupSize))
 };

--- a/lib/schema/provider.ts
+++ b/lib/schema/provider.ts
@@ -2,9 +2,9 @@ import * as Joi from 'joi';
 import { Regexes } from '../regexes';
 
 export const ProviderMap = {
-  npi: Joi.string().max(10).regex(Regexes.numbersOnly).required(),
-  firstName: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly).required(),
-  lastName: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly).required(),
+  npi: Joi.string().max(10).regex(Regexes.numbersOnly).trim().required(),
+  firstName: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly).trim().required(),
+  lastName: Joi.string().max(50).regex(Regexes.lettersAndSymbolsOnly).trim().required(),
   ein: Joi.string().max(15).regex(Regexes.lettersAndNumbersOnly).optional().allow(null),
   credentials: Joi.string().max(128).regex(Regexes.validCredentials).optional().allow(null),
   organizationId: Joi.number().required()

--- a/lib/schema/submission.ts
+++ b/lib/schema/submission.ts
@@ -1,7 +1,7 @@
 import * as Joi from 'joi';
 
 export const SubmissionMap = {
-  attribute: Joi.string().max(255).required(), // composite candidate key
+  attribute: Joi.string().max(255).trim().required(), // composite candidate key
   value: Joi.string().max(255).allow(null).empty(''),
   scope: Joi.string().max(255).allow(null).empty(''), // composite candidate key
   comments: Joi.string().allow(null),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/clinic.spec.ts
+++ b/test/clinic.spec.ts
@@ -1,0 +1,83 @@
+import * as Joi from 'joi';
+import { ClinicSchema } from '../lib/schema/clinic';
+
+describe('ClinicSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      clinicId: '123456789',
+      name: 'Clinic Name',
+      address1: null,
+      address2: null,
+      city: 'My City',
+      state: 'PA',
+      zipCode: '12345',
+      organizationId: 1
+    }, ClinicSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow partial objects', () => {
+    const result = Joi.validate({
+      clinicId: '123456789',
+      name: 'Clinic',
+      organizationId: 1
+    }, ClinicSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null address1', () => {
+    const result = Joi.validate({
+      address1: null,
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null address2', () => {
+    const result = Joi.validate({
+      address2: null
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null city', () => {
+    const result = Joi.validate({
+      city: null
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null state', () => {
+    const result = Joi.validate({
+      state: null
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null zipCode', () => {
+    const result = Joi.validate({
+      zipCode: null
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for clinicId', () => {
+    const result = Joi.validate({
+      clinicId: ' '
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for name', () => {
+    const result = Joi.validate({
+      name: ' '
+    }, ClinicSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/measure.spec.ts
+++ b/test/measure.spec.ts
@@ -1,0 +1,48 @@
+import * as Joi from 'joi';
+import { MeasureSchema } from '../lib/schema/measure';
+
+describe('MeasureSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      name: 'Measure Name',
+      helpDeskTicket: '1234567',
+      comments: 'comments'
+    }, MeasureSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow partial objects', () => {
+    const result = Joi.validate({
+      name: 'New name',
+    }, MeasureSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null helpDeskTicket', () => {
+    const result = Joi.validate({
+      helpDeskTicket: null,
+    }, MeasureSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null comments', () => {
+    const result = Joi.validate({
+      comments: null
+    }, MeasureSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, MeasureSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for name', () => {
+    const result = Joi.validate({
+      name: ' '
+    }, MeasureSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/notification.spec.ts
+++ b/test/notification.spec.ts
@@ -1,0 +1,36 @@
+import * as Joi from 'joi';
+import { NotificationSchema } from '../lib/schema/notification';
+
+describe('NotificationSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      userId: 1,
+      organizationId: 1,
+      messageType: 'ERROR',
+      message: 'message here',
+      read: true
+    }, NotificationSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should not allow unknown message types', () => {
+    const result = Joi.validate({
+      messageType: 'NOT_KNOWN'
+    }, NotificationSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, NotificationSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for message', () => {
+    const result = Joi.validate({
+      message: ' '
+    }, NotificationSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/organization-address.spec.ts
+++ b/test/organization-address.spec.ts
@@ -1,0 +1,44 @@
+import * as Joi from 'joi';
+import { OrganizationAddressSchema } from '../lib/schema/organization-address';
+
+describe('OrganizationAddressSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      address1: 'Address 1',
+      address2: null,
+      city: 'My city',
+      state: 'PA',
+      zipCode: '12345',
+      isPrimary: true
+    }, OrganizationAddressSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null address2', () => {
+    const result = Joi.validate({
+      address2: null,
+    }, OrganizationAddressSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, OrganizationAddressSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for city', () => {
+    const result = Joi.validate({
+      city: ' '
+    }, OrganizationAddressSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for address1', () => {
+    const result = Joi.validate({
+      address1: ' '
+    }, OrganizationAddressSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/organization-contact.spec.ts
+++ b/test/organization-contact.spec.ts
@@ -1,0 +1,50 @@
+import * as Joi from 'joi';
+import { OrganizationContactSchema } from '../lib/schema/organization-contact';
+
+describe('OrganizationContactSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      firstName: 'First',
+      lastName: 'Name',
+      email: 'me@me.com',
+      phone: '1234567890',
+      phoneExtension: '123456'
+    }, OrganizationContactSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null phoneExtension', () => {
+    const result = Joi.validate({
+      phoneExtension: null,
+    }, OrganizationContactSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, OrganizationContactSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for firstName', () => {
+    const result = Joi.validate({
+      firstName: ' '
+    }, OrganizationContactSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for lastName', () => {
+    const result = Joi.validate({
+      lastName: ' '
+    }, OrganizationContactSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for phone', () => {
+    const result = Joi.validate({
+      phone: ' '
+    }, OrganizationContactSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/organization.spec.ts
+++ b/test/organization.spec.ts
@@ -2,8 +2,44 @@ import * as Joi from 'joi';
 import { OrganizationSchema } from '../lib/schema/organization';
 
 describe('OrganizationSchema', () => {
-  describe('groupSize()', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      name: 'Name',
+      nickname: '1234567',
+      groupSize: '100 or More Individual Eligible Clinicians'
+    }, OrganizationSchema);
+    expect(result.error).toBeNull();
+  });
 
+  it('should allow partial objects', () => {
+    const result = Joi.validate({
+      name: 'New name',
+    }, OrganizationSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null nickname', () => {
+    const result = Joi.validate({
+      nickname: null,
+    }, OrganizationSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, OrganizationSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for name', () => {
+    const result = Joi.validate({
+      name: ' '
+    }, OrganizationSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  describe('groupSize()', () => {
     it('should validate correctly for 100+', () => {
       const result = Joi.validate({ name: 'a', groupSize: '100 or More Individual Eligible Clinicians' }, OrganizationSchema);
       expect(result.error).toBeNull();

--- a/test/provider.spec.ts
+++ b/test/provider.spec.ts
@@ -1,0 +1,58 @@
+import * as Joi from 'joi';
+import { ProviderSchema } from '../lib/schema/provider';
+
+describe('ProviderSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      npi: '123456789',
+      firstName: 'First',
+      lastName: 'Last',
+      ein: '123ertyu',
+      credentials: 'Credentials',
+      organizationId: 1
+    }, ProviderSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null ein', () => {
+    const result = Joi.validate({
+      ein: null,
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null credentials', () => {
+    const result = Joi.validate({
+      credentials: null
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for npi', () => {
+    const result = Joi.validate({
+      npi: ' '
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for firstName', () => {
+    const result = Joi.validate({
+      firstName: ' '
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for lastName', () => {
+    const result = Joi.validate({
+      lastName: ' '
+    }, ProviderSchema);
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/submission.spec.ts
+++ b/test/submission.spec.ts
@@ -1,0 +1,49 @@
+import * as Joi from 'joi';
+import { SubmissionSchema } from '../lib/schema/submission';
+
+describe('SubmissionSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate({
+      attribute: 'attriute string',
+      value: 'value',
+      scope: 'scope value',
+      comments: 'comments value'
+    }, SubmissionSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should allow null value:', () => {
+    const result = Joi.validate({
+      value: null,
+    }, SubmissionSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null scope', () => {
+    const result = Joi.validate({
+      scope: null
+    }, SubmissionSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should allow null comments', () => {
+    const result = Joi.validate({
+      comments: null
+    }, SubmissionSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow unknown fields', () => {
+    const result = Joi.validate({
+      someRandomProp: 'should not work'
+    }, SubmissionSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow empty value for attribute', () => {
+    const result = Joi.validate({
+      attribute: ' '
+    }, SubmissionSchema);
+    expect(result.error).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Updating required fields to not accept blank values. This is for the api side mostly... I will be opening a separate PR on the client to handle form validation.

`.trim()` trims the value during validation so any value that consists of only white spaces will be empty... therefore because it's required it will then fail validation.