### PR TITLE
feature/QPPBSR-5063: Validation for reset data endpoint

### DIFF
--- a/lib/schema/index.ts
+++ b/lib/schema/index.ts
@@ -10,3 +10,4 @@ export * from './organization-contact';
 export * from './organization-address';
 export * from './registration';
 export * from './submission';
+export * from './measure-reset';

--- a/lib/schema/measure-reset.ts
+++ b/lib/schema/measure-reset.ts
@@ -1,0 +1,3 @@
+import * as Joi from 'joi';
+
+export const MeasureResetSchema = Joi.array().items(Joi.string());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/measure-reset.spec.ts
+++ b/test/measure-reset.spec.ts
@@ -1,0 +1,27 @@
+import * as Joi from 'joi';
+import { MeasureResetSchema } from '../lib/schema/measure-reset';
+
+describe('MeasureResetSchema', () => {
+  it('should validate correctly', () => {
+    const result = Joi.validate([
+      'CARE-1',
+      'CARE-2',
+      'PREV-10'
+    ], MeasureResetSchema);
+    expect(result.error).toBeNull();
+  });
+
+  it('should not allow non string values in array', () => {
+    const result = Joi.validate([
+      1, 2, 'CARE-1'
+    ], MeasureResetSchema);
+    expect(result.error).not.toBeNull();
+  });
+
+  it('should not allow non array type', () => {
+    const result = Joi.validate({
+      bad: 1
+    }, MeasureResetSchema);
+    expect(result.error).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Adding measure reset schema that validates a request body equal to an array of strings.