### PR TITLE
QPPBSR-5546: update measure reset schema

### DIFF
--- a/lib/schema/measure-reset.ts
+++ b/lib/schema/measure-reset.ts
@@ -1,3 +1,8 @@
 import * as Joi from 'joi';
 
-export const MeasureResetSchema = Joi.array().items(Joi.string());
+export const MeasureResetMap = {
+  measureSelections: Joi.array().items(Joi.string()),
+  clearBeneficiaryConfirmation: Joi.boolean().required()
+};
+
+export const MeasureResetSchema = Joi.object(MeasureResetMap);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",

--- a/test/measure-reset.spec.ts
+++ b/test/measure-reset.spec.ts
@@ -3,25 +3,25 @@ import { MeasureResetSchema } from '../lib/schema/measure-reset';
 
 describe('MeasureResetSchema', () => {
   it('should validate correctly', () => {
-    const result = Joi.validate([
-      'CARE-1',
-      'CARE-2',
-      'PREV-10'
-    ], MeasureResetSchema);
+    const result = Joi.validate({
+      measureSelections:['CARE-1', 'CARE-2', 'PREV-10'],
+      clearBeneficiaryConfirmation: false
+    }, MeasureResetSchema);
     expect(result.error).toBeNull();
   });
 
   it('should not allow non string values in array', () => {
-    const result = Joi.validate([
-      1, 2, 'CARE-1'
-    ], MeasureResetSchema);
+    const result = Joi.validate({
+      measureSelections: [1, 2, 'CARE-1'],
+      clearBeneficiaryConfirmation: false
+    }, MeasureResetSchema);
     expect(result.error).not.toBeNull();
   });
 
-  it('should not allow non array type', () => {
-    const result = Joi.validate({
-      bad: 1
-    }, MeasureResetSchema);
+  it('should not allow non object type', () => {
+    const result = Joi.validate([
+      { bad: 1 }
+    ], MeasureResetSchema);
     expect(result.error).not.toBeNull();
   });
 });


### PR DESCRIPTION
update the measure reset payload to take an object with the following properties:

clearBeneficiaryConfirmation: boolean
measureSelections: string[]