### PR TITLE
QPPBSR-6061: Adding trim() to bene first and last name

### DIFF
--- a/lib/schema/beneficiary.ts
+++ b/lib/schema/beneficiary.ts
@@ -8,8 +8,8 @@ export enum Gender {
 }
 
 export const BeneficiaryMap = {
-  firstName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnlyWithPeriod),
-  lastName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnlyWithPeriod),
+  firstName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnlyWithPeriod).trim(),
+  lastName: Joi.string().max(128).regex(Regexes.lettersAndSymbolsOnlyWithPeriod).trim(),
   gender: Joi.string().valid(Object.values(Gender)),
   dateOfBirth: Joi.date(),
   mrn: Joi.string().max(128).allow(null),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",


### PR DESCRIPTION
Adding trim() to beneficiary first and last name in schema to validate against a user entering only spaces.