### PR TITLE
QPPBSR-6738: Skip Request | "Skip Request" pop-up modal missing error handling on email field

### DIFF
--- a/lib/regexes.ts
+++ b/lib/regexes.ts
@@ -14,8 +14,8 @@ export const Regexes = {
   validYear: /^(19|20)\d{2}$/,
   validDate: /^[0-1][0-9]\/[0-3][0-9]\/[1-2][0-9][0-9][0-9]/,
   validCredentials: /^[0-9a-zA-Z'\-\/#,;: ]+$/,
-  email: /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/,
+  email: /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/,
   stateAbbreviations: /^(AL|AK|AS|AZ|AR|CA|CO|CT|DE|DC|FL|GA|GU|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|MP|OH|OK|OR|PA|PR|RI|SC|SD|TN|TX|UT|VT|VI|VA|WA|WV|WI|WY)$/i
 }
 
-// email regex source - https://github.com/angular/angular/blob/master/packages/forms/src/validators.ts#L57
+// email regex source - https://www.w3resource.com/javascript/form/email-validation.php

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6196,11 +6196,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/wi-validation",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "CMS Web Interface Client and API Validation",
   "keywords": [
     "validation",


### PR DESCRIPTION
This PR update is to use a different email validator that will check for "@" and "."  followed by at least 2 characters.  The original email validation function didn't check for a "." followed by anything so an invalid email such as bob@semanticbits was considered valid.