### PR TITLE
task/qppbsr-10330 Update vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Thumbs.db
 .DS_Store
 
 # IDE
-.vscode
 .idea
 
 # Keep

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": "explicit"
+    }
+}


### PR DESCRIPTION
Update vscode settings for consistency across apps. 

This is part of a series of commits across all repos that will make all projects have the same vscode settings so we can all have more consistent commits and consistent PRs. This should cut down on the number of times we have to sift through auto linting that is occurring as one developer is setup to format one way and the next developer has a different setup. 

As part of this, each file should undergo a linting via prettier and import cleanup as well. This will trigger upon save of the file. This will eliminate the need to manually manage imports or worry about unused import, etc

**NOTE** Developers should expect to perhaps see many changes per file save occurring in the beginning, as some apps were not linting at all, or using different tab sizes, or import management, etc. the further we get into this, the fewer big changes we will see while saving.

> If you find that the settings are not triggering for you, it is likely due to you not opening the project from the correct folder. VS code looks at the root of the folder you opened for a folder called .vscode, and in there are the project settings. If you open your vscode from a different location, vscode will not see the project settings folder and not use the standard project settings. It is for this reason that we require the developer to open the root folder of the project when coding so we can maintain the kind of consistency introduced and enforcred in this pull request.

> If you choose to use an IDE that is not vscode, it is up to you to ensure you are using the same settings as defined in .vscode folder.

### Associated JIRA Tickets
https://jira.cms.gov/browse/QPPBSR-10330
